### PR TITLE
Only write the output buffer if it isn't empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,9 @@ func (w *lineWriter) Write(b []byte) (int, error) {
 }
 
 func (w *lineWriter) Flush() {
-	w.output(string(w.buffer))
+	if len(w.buffer) > 0 {
+		w.output(string(w.buffer))
+	}
 }
 
 func (t *tunnel) Provision(ui packer.Ui, comm packer.Communicator) error {


### PR DESCRIPTION
Missed this in the initial changes. Causes empty lines at the end of the tunnel provisioner output.
